### PR TITLE
Changed description from xip.io to nip.io

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -286,7 +286,7 @@
 				"nipio", "custom"
 			],
 			"metadata": {
-				"description": "Default Subdomain type - xip.io or custom (defined in next parameter)"
+				"description": "Default Subdomain type - nip.io or custom (defined in next parameter)"
 			}
 		},
 		"defaultSubDomain": {


### PR DESCRIPTION
Just reflecting that nip.io is now used instead of xip.io