### PR TITLE
Update deployOpenShift.sh

### DIFF
--- a/scripts/deployOpenShift.sh
+++ b/scripts/deployOpenShift.sh
@@ -439,6 +439,7 @@ openshift_logging_es_nodeselector={"type":"infra"}
 openshift_logging_kibana_nodeselector={"type":"infra"}
 openshift_logging_curator_nodeselector={"type":"infra"}
 openshift_master_logging_public_url=https://kibana.$ROUTING
+openshift_logging_master_public_url=https://$MASTERPUBLICIPHOSTNAME:8443
 
 # host group for masters
 [masters]


### PR DESCRIPTION
* Adding parameter **openshift_logging_master_public_url** under Logging project configurations .
*  As of now when Logging External URL is browsed it points to master-0 internal hostname for proxy authentication and hence fails. 
* Refer to Article: https://docs.openshift.org/latest/install_config/aggregate_logging.html#aggregate-logging-pre-deployment-configuration.
