### PR TITLE
avoid failure for deployment in case system is already registered 

### DIFF
--- a/scripts/bastionPrep.sh
+++ b/scripts/bastionPrep.sh
@@ -24,6 +24,9 @@ fi
 if [ $? -eq 0 ]
 then
    echo "Subscribed successfully"
+elif [ $? -eq 64 ]
+then
+   echo "This system is already registered."
 else
    echo "Incorrect Username and Password or Organization ID and / or Activation Key specified"
    exit 3


### PR DESCRIPTION
Deployment would fail if the system is already registered, this can happen in case of redeployment for the azure template .