### PR TITLE
fix for TSB pod failing during deploy

### DIFF
--- a/scripts/deployOpenShift.sh
+++ b/scripts/deployOpenShift.sh
@@ -133,6 +133,7 @@ openshift_registry_selector='type=infra'
 # openshift_enable_service_catalog=false
 
 # template_service_broker_install=false
+template_service_broker_selector={"type":"infra"}
 
 openshift_master_cluster_method=native
 openshift_master_cluster_hostname=$MASTERPUBLICIPHOSTNAME


### PR DESCRIPTION
Fix for Template Service Broker failing to deploy.  This is caused by the fact that the default node selector is set to region=infra by default, where the MSFT templates use type:infra.