### PR TITLE
recommended workaround for the docker.io not found error

### DIFF
--- a/scripts/deployOpenShift.sh
+++ b/scripts/deployOpenShift.sh
@@ -142,6 +142,11 @@ openshift_master_console_port=443
 osm_default_node_selector='region=app'
 openshift_disable_check=memory_availability,docker_image_availability
 
+# Workaround for docker image failure
+# https://access.redhat.com/solutions/3480921
+oreg_url=registry.access.redhat.com/openshift3/ose-\${component}:\${version}
+openshift_examples_modify_imagestreams=true
+
 # default selectors for router and registry services
 $registrygluster
 openshift_router_selector='region=infra'


### PR DESCRIPTION
For the azurestack-release-3.9 branch