### PR TITLE
Fix check of machines already registered in case of redeployment

### DIFF
--- a/scripts/bastionPrep.sh
+++ b/scripts/bastionPrep.sh
@@ -23,10 +23,11 @@ echo $(date) " - Register host with Cloud Access Subscription"
 
 subscription-manager register --username="$USERNAME_ORG" --password="$PASSWORD_ACT_KEY" || subscription-manager register --activationkey="$PASSWORD_ACT_KEY" --org="$USERNAME_ORG"
 
-if [ $? -eq 0 ]
+r=$?
+if [ $r -eq 0 ]
 then
     echo "Subscribed successfully"
-elif [ $? -eq 64 ]
+elif [ $r -eq 64 ]
 then
     echo "This system is already registered."
 else

--- a/scripts/masterPrep.sh
+++ b/scripts/masterPrep.sh
@@ -18,10 +18,11 @@ echo $(date) " - Register host with Cloud Access Subscription"
 
 subscription-manager register --username="$USERNAME_ORG" --password="$PASSWORD_ACT_KEY" || subscription-manager register --activationkey="$PASSWORD_ACT_KEY" --org="$USERNAME_ORG"
 
-if [ $? -eq 0 ]
+r=$?
+if [ $r -eq 0 ]
 then
     echo "Subscribed successfully"
-elif [ $? -eq 64 ]
+elif [ $r -eq 64 ]
 then
     echo "This system is already registered."
 else

--- a/scripts/nodePrep.sh
+++ b/scripts/nodePrep.sh
@@ -15,10 +15,11 @@ echo $(date) " - Register host with Cloud Access Subscription"
 
 subscription-manager register --username="$USERNAME_ORG" --password="$PASSWORD_ACT_KEY" || subscription-manager register --activationkey="$PASSWORD_ACT_KEY" --org="$USERNAME_ORG"
 
-if [ $? -eq 0 ]
+r=$?
+if [ $r -eq 0 ]
 then
     echo "Subscribed successfully"
-elif [ $? -eq 64 ]
+elif [ $r -eq 64 ]
 then
     echo "This system is already registered."
 else


### PR DESCRIPTION
In case we try to redeploy, we currently get a wrong error stating
that the password is wrong whereas the system is in fact already
registered.

Here is the error that this patch fixes:
```
$ az group deployment create --name openshift --template-uri https://raw.githubusercontent.com/Microsoft/openshift-container-platform/master/azuredeploy.json --parameters @azuredeploy.parameters.json --resource-group lenaic-ocp
Deployment failed. Correlation ID: 5da15d11-fa1f-4271-a910-865a32e60876. {
  "status": "Failed",
  "error": {
    "code": "ResourceDeploymentFailure",
    "message": "The resource operation completed with terminal provisioning state 'Failed'.",
    "details": [
      {
        "code": "VMExtensionProvisioningError",
        "message": "VM has reported a failure when processing extension 'prepNodes'. Error message: \"Enable failed: failed to execute command: command terminated with exit status=3\n[stdout]\nFri Jul 6 08:52:52 UTC 2018  - Starting Infra / Node Prep Script\nFri Jul 6 08:53:02 UTC 2018  - Register host with Cloud Access Subscription\nIncorrect Username / Password or Organization ID / Activation Key specified\n\n[stderr]\nThis system is already registered. Use --force to override\nThis system is already registered. Use --force to override\n\"."
      }
    ]
  }
}
```