### PR TITLE
Fix duplicate `git clone` in case of redeployment

### DIFF
--- a/scripts/deployOpenShift.sh
+++ b/scripts/deployOpenShift.sh
@@ -72,8 +72,8 @@ openshift_node_kubelet_args={'cloud-provider': ['azure'], 'cloud-config': ['/etc
 fi
 
 # Cloning Ansible playbook repository
-(cd /home/$SUDOUSER && git clone https://github.com/vincepower/openshift-container-platform-playbooks.git)
-#(cd /home/$SUDOUSER && git clone https://github.com/microsoft/openshift-container-platform-playbooks.git)
+(cd /home/$SUDOUSER && git clone https://github.com/vincepower/openshift-container-platform-playbooks.git || cd openshift-container-platform-playbooks && git pull)
+#(cd /home/$SUDOUSER && git clone https://github.com/microsoft/openshift-container-platform-playbooks.git || cd openshift-container-platform-playbooks && git pull)
 if [ -d /home/${SUDOUSER}/openshift-container-platform-playbooks ]
 then
     echo " - Retrieved playbooks successfully"


### PR DESCRIPTION
In case we try to redeploy, we currently get an error because git
tries to clone a repository whereas it is already thene.

Here is the error that this patch fixes:
```
$ az group deployment create --name openshift --template-uri https://raw.githubusercontent.com/Microsoft/openshift-container-platform/master/azuredeploy.json --parameters @azuredeploy.parameters.json --resource-group lenaic-ocp
Deployment failed. Correlation ID: 20135954-d79c-4770-94bb-63b3db90e6a0. {
  "status": "Failed",
  "error": {
    "code": "ResourceDeploymentFailure",
    "message": "The resource operation completed with terminal provisioning state 'Failed'.",
    "details": [
      {
        "code": "DeploymentFailed",
        "message": "At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-debug for usage details.",
        "details": [
          {
            "code": "Conflict",
            "message": "{\r\n  \"status\": \"Failed\",\r\n  \"error\": {\r\n    \"code\": \"ResourceDeploymentFailure\",\r\n    \"message\": \"The resource operation completed with terminal provisioning state 'Failed'.\",\r\n    \"details\": [\r\n      {\r\n        \"code\": \"VMExtensionProvisioningError\",\r\n        \"message\": \"VM has reported a failure when processing extension 'deployOpenShift'. Error message: \\\"Enable failed: failed to execute command: command terminated with exit status=1\\n[stdout]\\nFri Jul 6 14:17:59 UTC 2018  - Starting Script\\nConfiguring SSH ControlPath to use shorter path name\\n\\n[stderr]\\n  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\\n                                 Dload  Upload   Total   Spent    Left  Speed\\n\\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\\r100    13  100    13    0     0   1473      0 --:--:-- --:--:-- --:--:--  1625\\nfatal: destination path 'openshift-container-platform-playbooks' already exists and is not an empty directory.\\n\\\".\"\r\n      }\r\n    ]\r\n  }\r\n}"
          }
        ]
      }
    ]
  }
}
```